### PR TITLE
add postProcess param to ScioApp

### DIFF
--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/ScioApp.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/ScioApp.scala
@@ -35,6 +35,5 @@ abstract class ScioApp[Args](
     pipelineBuilder.buildPipeline(pipelineContext, parsedArgs)
     val result = pipelineContext.run().waitUntilDone()
     postProcess(result)
-    ()
   }
 }

--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/ScioApp.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/ScioApp.scala
@@ -4,10 +4,19 @@ import caseapp.Name
 import caseapp.core.help.Help
 import caseapp.core.parser.Parser
 import caseapp.core.util.Formatter
-import com.spotify.scio.ContextAndArgs
+import com.spotify.scio.{ContextAndArgs, ScioResult}
 
-/** Entry-point for command-line applications that run scio pipelines. */
-abstract class ScioApp[Args](implicit parser: Parser[Args], help: Help[Args]) {
+/**
+  * @param parser implicit parser doesn't need to be passed, derived from Args type
+  * @param help help generated from the Args type
+  * @param postProcess a post processing function if so desired
+  * @tparam Args an Args case class with input definitions and help messages
+  */
+abstract class ScioApp[Args](
+  implicit parser: Parser[Args],
+  help: Help[Args],
+  postProcess: ScioResult => Unit = _ => ()
+) {
   /** Builder which can convert command-line args into a pipeline. */
   def pipelineBuilder: PipelineBuilder[Args]
 
@@ -20,11 +29,12 @@ abstract class ScioApp[Args](implicit parser: Parser[Args], help: Help[Args]) {
     * Parses command-line args, constructs a pipeline, runs the
     * pipeline, and waits for the pipeline to finish.
     */
-  final def main(args: Array[String]): Unit = {
+  def main(args: Array[String]): Unit = {
     val (pipelineContext, parsedArgs) =
       ContextAndArgs.typed[Args](args)(parser.nameFormatter(argFormatter), help)
     pipelineBuilder.buildPipeline(pipelineContext, parsedArgs)
-    pipelineContext.run().waitUntilDone()
+    val result = pipelineContext.run().waitUntilDone()
+    postProcess(result)
     ()
   }
 }


### PR DESCRIPTION
update the ScioApp abstract class so that it can accept a postProcess parameter (where the default doesn't do anything). A default is provided so as to be backwards compatible when a pipeline's version is updated, but this allows us to hook in processing the pipeline result in a very flexible way. Also added a docstring to the class.