### PR TITLE
ra DSPDC 1226 limit file writes

### DIFF
--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
@@ -49,14 +49,15 @@ object StorageIO {
   def writeJsonLists(
     messages: SCollection[Msg],
     description: String,
-    outputPrefix: String
+    outputPrefix: String,
+    numShards: Int = 0
   ): ClosedTap[String] =
     messages
       .transform(s"Stringify '$description' messages")(
         _.map(upack.transform(_, StringRenderer()).toString)
       )
       .withName(s"Write '$description' messages to '$outputPrefix'")
-      .saveAsTextFile(outputPrefix, suffix = ".json")
+      .saveAsTextFile(outputPrefix, suffix = ".json", numShards = numShards)
 
   /**
     * Write modeled messages to storage for use by downstream components.


### PR DESCRIPTION
Add number of shards as an input to writeJsonLists, with a default of 0 to maintain existing behavior for wherever it is used as is. This needs to be tested in another project, but it requires us to push a new version to try out in other projects.