### PR TITLE
Ra split writeJsonLists into two functions

### DIFF
--- a/.github/workflows/build-and-publish-master.yaml
+++ b/.github/workflows/build-and-publish-master.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Fetch tag history
         run: git fetch --tags
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/.github/workflows/build-and-publish-release.yaml
+++ b/.github/workflows/build-and-publish-release.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Publish

--- a/.github/workflows/validate-pull-request.yaml
+++ b/.github/workflows/validate-pull-request.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
         with:
           java-version: graalvm@20.0.0
       - name: Check formatting

--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
@@ -46,7 +46,7 @@ object StorageIO {
     * Each message will be written to a single line in a part-file under the given
     * output prefix.
     */
-  def writeJsonLists(
+  def writeJsonListsGeneric(
     messages: SCollection[Msg],
     description: String,
     outputPrefix: String,
@@ -69,7 +69,7 @@ object StorageIO {
     messages: SCollection[M],
     description: String,
     outputPrefix: String,
-    numShards: Int
+    numShards: Int = 0
   ): ClosedTap[String] =
     messages
       .transform(s"Stringify '$description' messages")(

--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
@@ -69,7 +69,7 @@ object StorageIO {
     messages: SCollection[M],
     description: String,
     outputPrefix: String,
-    numShards: Int = 0
+    numShards: Int
   ): ClosedTap[String] =
     messages
       .transform(s"Stringify '$description' messages")(

--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
@@ -68,12 +68,13 @@ object StorageIO {
   def writeJsonLists[M: Encoder](
     messages: SCollection[M],
     description: String,
-    outputPrefix: String
+    outputPrefix: String,
+    numShards: Int = 0
   ): ClosedTap[String] =
     messages
       .transform(s"Stringify '$description' messages")(
         _.map(_.asJson.printWith(circePrinter))
       )
       .withName(s"Write '$description' messages to '$outputPrefix'")
-      .saveAsTextFile(outputPrefix, suffix = ".json")
+      .saveAsTextFile(outputPrefix, suffix = ".json", numShards = numShards)
 }

--- a/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/StorageIOSpec.scala
+++ b/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/StorageIOSpec.scala
@@ -68,7 +68,7 @@ class StorageIOSpec extends PipelineSpec {
   it should "write generic messages as JSON-list" in {
     File.temporaryDirectory().foreach { tmpDir =>
       runWithRealContext(PipelineOptionsFactory.create()) { sc =>
-        StorageIO.writeJsonLists(
+        StorageIO.writeJsonListsGeneric(
           sc.parallelize(msgs),
           "Test Write",
           tmpDir.pathAsString

--- a/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/StorageIOSpec.scala
+++ b/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/StorageIOSpec.scala
@@ -80,6 +80,25 @@ class StorageIOSpec extends PipelineSpec {
     }
   }
 
+  it should "write a specified number of output files" in {
+    val numShards = 2
+    File.temporaryDirectory().foreach { tmpDir =>
+      runWithRealContext(PipelineOptionsFactory.create()) { sc =>
+        StorageIO.writeJsonListsGeneric(
+          sc.parallelize(msgs),
+          "Test Write",
+          tmpDir.pathAsString,
+          numShards = numShards
+        )
+      }
+      val numFiles = tmpDir.listRecursively().count(_.name.endsWith(".json"))
+      numFiles shouldBe numShards
+      val written =
+        tmpDir.listRecursively().filter(_.name.endsWith(".json")).flatMap(_.lines).toList
+      written should contain allElementsOf jsons
+    }
+  }
+
   it should "write modeled messages as JSON-list" in {
     File.temporaryDirectory().foreach { tmpDir =>
       runWithRealContext(PipelineOptionsFactory.create()) { sc =>


### PR DESCRIPTION
## Why
We need to make sure that we can specify the number of output files to write for certain cases (for example, when writing a file that is to be consumed by the Jade bulkFileIngest endpoint, we need exactly ONE control file, not a directory full of however many files).

## This PR
Pulls common code into another method, applies default argument to both writeJsonLists functions, and adds a test to make sure it actually writes the specified number of files. Also bumps up the setup-scala GH action version.