### PR TITLE
Add new parse json method

### DIFF
--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/msg/JsonParser.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/msg/JsonParser.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.monster.common.msg
 
-import io.circe.Json
+import io.circe.{Json, ParsingFailure}
 import upack.Msg
 import upickle.core.Visitor
 
@@ -13,10 +13,24 @@ object JsonParser {
     * better preserve distinctions between numeric types.
     */
   def parseEncodedJson(json: String): Msg = {
-    val maybeParsed = io.circe.parser.parse(json)
+    val maybeParsed: Either[ParsingFailure, Json] = io.circe.parser.parse(json)
     maybeParsed.fold(
       err => throw new Exception(s"Failed to parse input line as JSON: $json", err),
       js => transform(js, Msg)
+    )
+  }
+
+  /**
+    * Parse encoded JSON into a upack Msg.
+    *
+    * This differs from parseEncodedJson by not throwing on error, but rather
+    * returning an Either[ParsingFailure, Msg].
+    */
+  def parseEncodedJsonReturningFailure(json: String): Either[ParsingFailure, Msg] = {
+    val maybeParsed: Either[ParsingFailure, Json] = io.circe.parser.parse(json)
+    maybeParsed.fold(
+      err => Left(err),
+      js => Right(transform(js, Msg))
     )
   }
 

--- a/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/msg/JsonParserSpec.scala
+++ b/ingest-scio-utils/src/test/scala/org/broadinstitute/monster/common/msg/JsonParserSpec.scala
@@ -52,4 +52,14 @@ class JsonParserSpec extends AnyFlatSpec with Matchers {
       Obj(Str("foo") -> Str("bar"), Str("ok") -> Bool(true))
     )
   }
+
+  it should "parse JSON objects and return the result" in {
+    val result = JsonParser.parseEncodedJsonReturningFailure("[]")
+    result.isRight shouldBe true
+  }
+
+  it should "parse invalid JSON objects and return the result" in {
+    val result = JsonParser.parseEncodedJsonReturningFailure("invalid")
+    result.isLeft shouldBe true
+  }
 }


### PR DESCRIPTION
## Why
When we get garbage data back from Redcap in the dog aging project, but not a 500, we are not catching the resulting exception and the pipeline never terminates (at least in integration testing, I have not observed this in dataflow). We have two client interfaces: 
* Handle the exception:
```
try { 
  p.success(JsonParser.parseEncodedJson(response.body().string()))
} catch {
  case ex: Exception => p.failure(ex)
}
```
* Adjust the ingest-utils code to return an `Either[ParsingFailure, Msg]` and allow the client to match on that, 
```
val maybeResult = JsonParser.parseWithTry(response.body().string())
maybeResult match {
    case Right(result) => p.success(result)
    case Left(err)     => p.failure(err)
}
```

I prefer the pattern matching approach to force the client to deal with the maybe-ness of the result (and the consequent cleanup). 

## This PR
* Adds a new `parseEncodedJsonReturningFailure` method with the semantics outlined above (very open to naming suggestions), along with a test. If this works, we can tag the `parseEncodedJson` method with an `@deprecated`.
