### PR TITLE
Upgrade to beam 2.24 to maintain parity with scio 0.9.5 dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val `ingest-sbt-plugins` = project
 // build itself, while everything below is going to be injected as app-level libraries.
 // There's no inherent need to keep the two in-sync, and if we ever want to port to
 // Scala 2.13 before sbt catches up it's very likely the two lists will drift.
-val beamVersion = "2.20.0"
+val beamVersion = "2.24.0"
 val betterFilesVersion = "3.8.0"
 val circeVersion = "0.13.0"
 val circeDerivationVersion = "0.13.0-M4"


### PR DESCRIPTION
## Why
I'm running to abstract method errors when testing the 2.1.5 release against dog-aging-ingest. I suspect this is due to a missing/mismatched dependency. According to the `ingest-scio-utils` readme, we should be keeping our upstream beam dep in lockstep with what scio has documented for that release. According to their [releases](https://github.com/spotify/scio/releases/tag/v0.9.5) page, they upgraded the beam dep to 2.24 in 0.9.5

## This PR
* Bumps the beam version to 2.24.0.