### PR TITLE
Upgrade Scala to 2.13.1

### DIFF
--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
@@ -62,7 +62,7 @@ object MonsterBasePlugin extends AutoPlugin {
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(
       organization := "org.broadinstitute.monster",
-      scalaVersion := "2.12.13",
+      scalaVersion := "2.13.1",
       scalacOptions ++= {
         val snapshot = isSnapshot.value
         val base = Seq(
@@ -125,9 +125,6 @@ object MonsterBasePlugin extends AutoPlugin {
           "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",
           "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/"
         ),
-        // pinned kind-projector version due to regression in scala 2.12.13
-        // https://github.com/typelevel/kind-projector/issues/116
-        addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full),
         addCompilerPlugin(
           "com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion
         ),

--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
@@ -62,7 +62,7 @@ object MonsterBasePlugin extends AutoPlugin {
   override def buildSettings: Seq[Def.Setting[_]] =
     Seq(
       organization := "org.broadinstitute.monster",
-      scalaVersion := "2.12.11",
+      scalaVersion := "2.12.13",
       scalacOptions ++= {
         val snapshot = isSnapshot.value
         val base = Seq(

--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
@@ -66,7 +66,7 @@ object MonsterBasePlugin extends AutoPlugin {
       scalacOptions ++= {
         val snapshot = isSnapshot.value
         val base = Seq(
-          "-deprecation",
+          "-Xlint:deprecation",
           "-encoding",
           "UTF-8",
           "-explaintypes",
@@ -74,11 +74,9 @@ object MonsterBasePlugin extends AutoPlugin {
           "-target:jvm-1.8",
           "-unchecked",
           "-Xfatal-warnings",
-          "-Xfuture",
+          "-Xsource:2.14",
+          "-Xmigration",
           "-Xlint",
-          "-Xmax-classfile-name",
-          "200",
-          "-Yno-adapted-args",
           "-Ypartial-unification",
           "-Ywarn-dead-code",
           "-Ywarn-extra-implicit",

--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
@@ -125,6 +125,9 @@ object MonsterBasePlugin extends AutoPlugin {
           "Broad Artifactory Releases" at "https://broadinstitute.jfrog.io/broadinstitute/libs-release/",
           "Broad Artifactory Snapshots" at "https://broadinstitute.jfrog.io/broadinstitute/libs-snapshot/"
         ),
+        // pinned kind-projector version due to regression in scala 2.12.13
+        // https://github.com/typelevel/kind-projector/issues/116
+        addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full)
         addCompilerPlugin(
           "com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion
         ),

--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterBasePlugin.scala
@@ -127,7 +127,7 @@ object MonsterBasePlugin extends AutoPlugin {
         ),
         // pinned kind-projector version due to regression in scala 2.12.13
         // https://github.com/typelevel/kind-projector/issues/116
-        addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full)
+        addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.11.3" cross CrossVersion.full),
         addCompilerPlugin(
           "com.olegpy" %% "better-monadic-for" % BetterMonadicForVersion
         ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ Compile / unmanagedSourceDirectories +=
 
 // Needed for the dog-fooding setup, apparently.
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ Compile / unmanagedSourceDirectories +=
 
 // Needed for the dog-fooding setup, apparently.
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.3")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")


### PR DESCRIPTION
This gives us access to the `unused` annotation. There are legitimate cases where it's impossible to avoid a warning from Ywarn-unused, which is elevated to an error by Xfatal-warnings, so this annotation lets us write such code without needing to outright disable otherwise-helpful warnings.