### PR TITLE
Update graalvm Docker image

### DIFF
--- a/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterDockerPlugin.scala
+++ b/core-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/core/MonsterDockerPlugin.scala
@@ -19,7 +19,7 @@ object MonsterDockerPlugin extends AutoPlugin with LinuxKeys with NativePackager
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
-      dockerBaseImage := "oracle/graalvm-ce:20.0.0-java8",
+      dockerBaseImage := "ghcr.io/graalvm/graalvm-ce:ol7-java8-20.3.1",
       dockerRepository := Some("us.gcr.io/broad-dsp-gcr-public"),
       dockerLabels := Map("VERSION" -> version.value),
       Docker / defaultLinuxInstallLocation := "/app",


### PR DESCRIPTION
## Why
The graalvm docker image we use has been removed (https://broadinstitute.atlassian.net/browse/DSPDC-1475).We need to point to a new image.

## This PR
* Updates the docker image we use to what I think is a reasonably close version 
  * I couldn't find an image published by the graal team that exactly matches the 20.0.0 version we were using previously so I chose to at least keep the same major version