### PR TITLE
Parameterize printer in JSON serialization StorageIO function

### DIFF
--- a/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
+++ b/ingest-scio-utils/src/main/scala/org/broadinstitute/monster/common/StorageIO.scala
@@ -94,11 +94,12 @@ object StorageIO {
     messages: SCollection[M],
     description: String,
     outputPrefix: String,
-    numShards: Int = 0
+    numShards: Int = 0,
+    printer: Printer = circePrinter
   ): ClosedTap[String] =
     writeJsonListsCommon(
       messages,
-      (msg: M) => msg.asJson.printWith(circePrinter),
+      (msg: M) => msg.asJson.printWith(printer),
       description,
       outputPrefix,
       numShards = numShards


### PR DESCRIPTION
This will let us pass in a different printer with custom config, e.g. leaving in null-valued keys