### PR TITLE
Upgrade SCIO + Beam to latest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,12 +43,12 @@ lazy val `ingest-sbt-plugins` = project
 // build itself, while everything below is going to be injected as app-level libraries.
 // There's no inherent need to keep the two in-sync, and if we ever want to port to
 // Scala 2.13 before sbt catches up it's very likely the two lists will drift.
-val beamVersion = "2.24.0"
+val beamVersion = "2.27.0"
 val betterFilesVersion = "3.8.0"
 val circeVersion = "0.13.0"
 val circeDerivationVersion = "0.13.0-M4"
 val logbackVersion = "1.2.3"
-val scioVersion = "0.9.5"
+val scioVersion = "0.10.2"
 val uPickleVersion = "1.0.0"
 
 val scalatestVersion = "3.1.1"


### PR DESCRIPTION
## Why
We are out of date with the latest SCIO and beam versions.

## This PR
* Brings us up to date.