### PR TITLE
[DSPDC-1791] Expose helm chart linting as a task

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,12 +43,12 @@ lazy val `ingest-sbt-plugins` = project
 // build itself, while everything below is going to be injected as app-level libraries.
 // There's no inherent need to keep the two in-sync, and if we ever want to port to
 // Scala 2.13 before sbt catches up it's very likely the two lists will drift.
-val beamVersion = "2.27.0"
+val beamVersion = "2.29.0"
 val betterFilesVersion = "3.8.0"
 val circeVersion = "0.13.0"
 val circeDerivationVersion = "0.13.0-M4"
 val logbackVersion = "1.2.3"
-val scioVersion = "0.10.2"
+val scioVersion = "0.10.3"
 val uPickleVersion = "1.0.0"
 
 val scalatestVersion = "3.1.1"

--- a/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/helm/MonsterHelmPlugin.scala
+++ b/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/helm/MonsterHelmPlugin.scala
@@ -41,7 +41,7 @@ object MonsterHelmPlugin extends AutoPlugin {
     Seq(
       // Test-related settings.
       Test / helmExampleValuesSource := baseDirectory.value / "example-values",
-      Test / test := {
+      Test / lintHelmChart := {
         val log = streams.value.log
         val chart = baseDirectory.value
         val examples = (Test / helmExampleValuesSource).value.glob("*.yaml")
@@ -60,6 +60,7 @@ object MonsterHelmPlugin extends AutoPlugin {
           sys.error(s"Linting failed for example(s): ${failedExamples.mkString(", ")}")
         }
       },
+      test := (Test / lintHelmChart).value,
       // Publish-related settings.
       helmStagingDirectory := target.value / "helm" / "packaged",
       helmChartLocalIndex := target.value / "helm" / "index.yaml",

--- a/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/helm/MonsterHelmPluginKeys.scala
+++ b/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/helm/MonsterHelmPluginKeys.scala
@@ -36,4 +36,6 @@ trait MonsterHelmPluginKeys {
   val reindexHelmRepository: TaskKey[Unit] = taskKey(
     "Update the index.yaml for the project's Helm repository"
   )
+
+  val lintHelmChart: TaskKey[Unit] = taskKey("Lint the project's Helm chart")
 }


### PR DESCRIPTION
## Why
During testing of the YAML modifications for DSPDC-1791, I bumped into invalid YAML several times. We have a lint task for this, but it requires a full test suite run as it's attached at the `test` scope. It would be useful to be able to lint the chart without a full test suite run.

## This PR
* Creates a new `lintHelmChart` task key and assigns the helm chart linting code to it so it's invocable by external projects like HCA
* "Aliases" the `test` task to the `lintHelmChart` so it runs by default during test runs as well
* Upgrades SCIO + Beam 