### PR TITLE
Expand allowable characters in jade column names

### DIFF
--- a/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/jade/model/JadeIdentifier.scala
+++ b/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/jade/model/JadeIdentifier.scala
@@ -21,7 +21,7 @@ class JadeIdentifier private[sbt] (private[sbt] val id: String) {
 
 object JadeIdentifier {
   /** Pattern matching valid Jade IDs. */
-  private val idPattern = "^[a-z][a-z0-9_]{0,62}$".r
+  private val idPattern = "^[a-zA-Z][a-zA-Z0-9_]{0,62}$".r
 
   implicit val encoder: Encoder[JadeIdentifier] =
     Encoder[String].contramap(_.id)

--- a/ingest-sbt-plugins/src/test/scala/org/broadinstitute/monster/sbt/jade/ClassGeneratorSpec.scala
+++ b/ingest-sbt-plugins/src/test/scala/org/broadinstitute/monster/sbt/jade/ClassGeneratorSpec.scala
@@ -638,7 +638,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
   )
   it should behave like checkFailedTableGeneration(
     "catch invalid table identifiers",
-    """{ "name": "tableOne", "columns": [] }""",
+    """{ "name": "123tableOne", "columns": [] }""",
     "not a valid Jade identifier"
   )
   it should behave like checkFailedTableGeneration(
@@ -951,7 +951,7 @@ class ClassGeneratorSpec extends AnyFlatSpec with Matchers with EitherValues {
   )
   it should behave like checkFailedStructGeneration(
     "catch invalid struct identifiers",
-    """{ "name": "structOne", "fields": [] }""",
+    """{ "name": "1231structOne", "fields": [] }""",
     "not a valid Jade identifier"
   )
   it should behave like checkFailedStructGeneration(

--- a/ingest-sbt-plugins/src/test/scala/org/broadinstitute/monster/sbt/jade/model/JadeIdentifierSpec.scala
+++ b/ingest-sbt-plugins/src/test/scala/org/broadinstitute/monster/sbt/jade/model/JadeIdentifierSpec.scala
@@ -12,21 +12,6 @@ class JadeIdentifierSpec extends AnyFlatSpec with Matchers with EitherValues {
     attempt.left.value should include("not a valid Jade identifier")
   }
 
-  it should "reject capital letters at the beginning of words" in {
-    val attempt = JadeIdentifier.fromString("TableName")
-    attempt.left.value should include("not a valid Jade identifier")
-  }
-
-  it should "reject capital letters in the middle of words" in {
-    val attempt = JadeIdentifier.fromString("columnName")
-    attempt.left.value should include("not a valid Jade identifier")
-  }
-
-  it should "reject capital letters at the end of words" in {
-    val attempt = JadeIdentifier.fromString("columnA")
-    attempt.left.value should include("not a valid Jade identifier")
-  }
-
   it should "reject kebab-case strings" in {
     val attempt = JadeIdentifier.fromString("the-column")
     attempt.left.value should include("not a valid Jade identifier")


### PR DESCRIPTION
We need to be more lenient with our allowed characters in Jade column names.
* Allow upper case first characters in column names
* Allow upper case subsequent characters in column names