### PR TITLE
Escape table names

### DIFF
--- a/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/jade/ClassGenerator.scala
+++ b/ingest-sbt-plugins/src/main/scala/org/broadinstitute/monster/sbt/jade/ClassGenerator.scala
@@ -309,7 +309,7 @@ object ClassGenerator {
 
   /** Get the Scala field name for a Jade column. */
   private def getFieldName(columnName: JadeIdentifier): String = {
-    val rawColumnName = formatField(columnName, titleCase = false)
+    val rawColumnName = snakeToCamel(columnName, titleCase = false)
     if (keywords.contains(rawColumnName)) s"`$rawColumnName`" else rawColumnName
   }
 


### PR DESCRIPTION
Table names that use a reserved scala keyword should be escaped with a backtick "`"

